### PR TITLE
Correct "role @ company_name" typo on slide 1 page #44 (Guest Lectures)

### DIFF
--- a/slides/2017/01_course_introduction/index.html
+++ b/slides/2017/01_course_introduction/index.html
@@ -642,7 +642,7 @@ Final letter grades will be assigned as indicated at:
 
 * Courtney Wang, Senior Software Engineer @ Reddit
 
-* Andrew Mutz, CTO & AppFolio
+* Andrew Mutz, CTO @ AppFolio
 
 
 ---


### PR DESCRIPTION
It previously said Andrew Mutz, CTO & AppFolio.