### PR TITLE
remove hidden-xs class from sidebar

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -2,7 +2,7 @@
 
 <div class="container container-left">
   <div class="row">
-    <div class="col-md-3 hidden-xs">
+    <div class="col-md-3">
       {% include sidebar.html %}
     </div>
     <div class="col-md-9">


### PR DESCRIPTION
Removal of the hidden-xs bootstrap class refrains browsers from hiding sidebar in viewports similar to mobile devices.