### PR TITLE
Fix typo on HTTP slides

### DIFF
--- a/slides/2018/02_http/index.html
+++ b/slides/2018/02_http/index.html
@@ -152,7 +152,7 @@ __HyperText__: Links documents together via __HyperLinks__
 
 # HTTP Explained
 
-It its original, simplest version:
+In its original, simplest version:
 
 * Open a TCP socket (standard port is 80)
 


### PR DESCRIPTION
Originally said "It its original, simplest version...". Changed it to "In its original, simplest version...".