### PR TITLE
decode python3 bytes to string

### DIFF
--- a/scripts/project1.py
+++ b/scripts/project1.py
@@ -165,7 +165,7 @@ def test_root__invalid_timeliness(url):
 def test_root__invalid_tokens(url):
     failures = 0
     for security in [(None, "none"), ("NOTASECRET", "HS256")]:
-        token = jwt.encode({"data": 1}, *security)
+        token = jwt.encode({"data": 1}, *security).decode("utf-8")
         response = requests.get(
             url,
             allow_redirects=False,


### PR DESCRIPTION
Although this behavior is not mentioned in the docs, the python3 jwt.encode() appears to produce bytes instead of strings, and so the header is "Authorization"=>"Bearer b'eyJ0eXAiOiJKV1QiLCJhbGciOiJub25lIn0.eyJkYXRhIjoxfQ.'" (note the b'...') While this would also result in 403, it is raising JWT::DecodeError("Invalid segment encoding") instead of JWT::VerificationError("Signature verification raised") and so does not test invalid tokens.