### PR TITLE
Decode websites using UTF-8 to support emojis

### DIFF
--- a/scripts/project0.py
+++ b/scripts/project0.py
@@ -181,7 +181,7 @@ def score(url):
     if response.status_code != 200:
         print(f"URL responded with non 200 status: {response.status_code}")
         return failures + 1  # Cannot continue
-    content = response.content.decode('utf-8')
+    content = response.content.decode("utf-8")
 
     if response.history:
         print("URL redirected more than 0 times:")

--- a/scripts/project0.py
+++ b/scripts/project0.py
@@ -18,7 +18,7 @@ def main():
     if len(sys.argv) == 1:
         local_file = "example.html"
         print(f"No args given, scoring local file {local_file}")
-        with open(local_file, "r") as fp:
+        with open(local_file, mode="r", encoding="utf-8") as fp:
             content = fp.read()
         return page_issues(content, "file:///" + local_file)
 
@@ -181,7 +181,7 @@ def score(url):
     if response.status_code != 200:
         print(f"URL responded with non 200 status: {response.status_code}")
         return failures + 1  # Cannot continue
-    content = response.content
+    content = response.content.decode('utf-8')
 
     if response.history:
         print("URL redirected more than 0 times:")


### PR DESCRIPTION
This PR addresses a bug in the Project 0 validation script where websites with emoji characters will not parse correctly and will fail various parts of the validation script. By forcing the website to be decoded using the UTF-8 format, which supports emojis, we can properly evaluate websites that contain them.

Test with the website https://andrewhlu.com/cookies/, which contains emojis in both the title and body.