### PR TITLE
ruby version update

### DIFF
--- a/project.md
+++ b/project.md
@@ -296,7 +296,7 @@ jobs:
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 2.7.2
+        ruby-version: 3.0.2
         bundler-cache: true
     - name: Set up yarn
       run: |


### PR DESCRIPTION
When creating the docker images ruby is installed with the latest version (3.0.2). Workflow ruby version needs to update in order to be complete.