### PR TITLE
FIx lxml in dockerfile

### DIFF
--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -4,6 +4,7 @@ WORKDIR /app
 COPY requirements.txt .
 RUN apt-get update && \
     apt-get install wamerican && \
-    pip install --no-cache-dir -r requirements.txt
+    pip install --no-cache-dir -r requirements.txt \
+    pip install --no-binary lxml lxml
 
 COPY *.py ./


### PR DESCRIPTION
We used to have an issue with lxml when running `docker run -it --rm cs291_scripts ./project0.py https://twitter.github.io`. I fix it now.