### PR TITLE
Update Dockerfile, swap install order

### DIFF
--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /app
 COPY requirements.txt .
 RUN apt-get update && \
     apt-get install wamerican && \
-    pip install --no-cache-dir -r requirements.txt \
-    pip install --no-binary lxml lxml
+    pip install --no-binary lxml lxml && \
+    pip install --no-cache-dir -r requirements.txt
 
 COPY *.py ./


### PR DESCRIPTION
Added && to line 7;
Swapped line 7 and 8 so that lxml is installed first in order to avoid the error "RuntimeError: html5-parser and lxml are using different versions of libxml2"
Relevant discussion in https://piazza.com/class/m0v6wccmebz5zk/post/10